### PR TITLE
Updated 'attach' cellular test for C030_U201

### DIFF
--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -546,10 +546,27 @@ nsapi_error_t AT_CellularNetwork::set_registration(const char *plmn)
 
     if (!plmn) {
         tr_debug("Automatic network registration");
+#if defined(TARGET_UBLOX_C030_U201) // Need to define generic flag for all ublox variants
+        uint8_t len=8;
+        uint8_t buf[len];
+        _at.cmd_start("AT+COPS?");
+        _at.cmd_stop();
+        _at.resp_start();
+        _at.read_bytes(buf,len);
+        _at.resp_stop();
+        if(strncmp((char*)buf,"+COPS: 0",len)!=0) {
+            _at.clear_error();
+            _at.cmd_start("AT+COPS=0");
+            _at.cmd_stop();
+            _at.resp_start();
+            _at.resp_stop();
+        }
+#else
         _at.cmd_start("AT+COPS=0");
         _at.cmd_stop();
         _at.resp_start();
         _at.resp_stop();
+#endif
     } else {
         tr_debug("Manual network registration to %s", plmn);
         _at.cmd_start("AT+COPS=4,2,");


### PR DESCRIPTION
Updated 'attach' cellular test for C030_U201 only but need to define generic flag for all ublox variants.
