### PR TITLE
Renaming UBLOX library for mbed cellular framework

### DIFF
--- a/features/cellular/framework/common/CellularTargets.h
+++ b/features/cellular/framework/common/CellularTargets.h
@@ -28,9 +28,9 @@ namespace mbed {
 #elif TARGET_MTB_MTS_DRAGONFLY
 #define CELLULAR_DEVICE TELIT_HE910
 #elif TARGET_UBLOX_C030
-#define CELLULAR_DEVICE UBLOX_LISA_U
+#define CELLULAR_DEVICE UBLOX_PPP
 #elif TARGET_UBLOX_C027
-#define CELLULAR_DEVICE UBLOX_LISA_U
+#define CELLULAR_DEVICE UBLOX_PPP
 #else
 //#error Cellular target not defined, see cellular/targets.h
 //#define CELLULAR_TARGET <target-modem>

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.cpp
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.cpp
@@ -15,30 +15,33 @@
  * limitations under the License.
  */
 
-#include "UBLOX_LISA_U_CellularNetwork.h"
+#include "UBLOX_PPP.h"
+#include "UBLOX_PPP_CellularNetwork.h"
+#include "UBLOX_PPP_CellularPower.h"
 
 using namespace mbed;
+using namespace events;
 
-UBLOX_LISA_U_CellularNetwork::UBLOX_LISA_U_CellularNetwork(ATHandler &atHandler) : AT_CellularNetwork(atHandler)
+UBLOX_PPP::UBLOX_PPP(EventQueue &queue) : AT_CellularDevice(queue)
 {
 }
 
-UBLOX_LISA_U_CellularNetwork::~UBLOX_LISA_U_CellularNetwork()
+UBLOX_PPP::~UBLOX_PPP()
 {
 }
 
-bool UBLOX_LISA_U_CellularNetwork::get_modem_stack_type(nsapi_ip_stack_t requested_stack)
+CellularNetwork *UBLOX_PPP::open_network(FileHandle *fh)
 {
-    return requested_stack == IPV4_STACK ? true : false;
+    if (!_network) {
+        _network = new UBLOX_PPP_CellularNetwork(*get_at_handler(fh));
+    }
+    return _network;
 }
 
-bool UBLOX_LISA_U_CellularNetwork::has_registration(RegistrationType reg_type)
+CellularPower *UBLOX_PPP::open_power(FileHandle *fh)
 {
-    return (reg_type == C_REG || reg_type == C_GREG);
-}
-
-nsapi_error_t UBLOX_LISA_U_CellularNetwork::set_access_technology_impl(operator_t::RadioAccessTechnology opRat)
-{
-    _op_act = operator_t::RAT_UNKNOWN;
-    return NSAPI_ERROR_UNSUPPORTED;
+    if (!_power) {
+        _power = new UBLOX_PPP_CellularPower(*get_at_handler(fh));
+    }
+    return _power;
 }

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.h
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.h
@@ -15,33 +15,25 @@
  * limitations under the License.
  */
 
-#include "UBLOX_LISA_U.h"
-#include "UBLOX_LISA_U_CellularNetwork.h"
-#include "UBLOX_LISA_U_CellularPower.h"
+#ifndef UBLOX_PPP_H_
+#define UBLOX_PPP_H_
 
-using namespace mbed;
-using namespace events;
+#include "AT_CellularDevice.h"
 
-UBLOX_LISA_U::UBLOX_LISA_U(EventQueue &queue) : AT_CellularDevice(queue)
+namespace mbed {
+
+class UBLOX_PPP : public AT_CellularDevice
 {
-}
 
-UBLOX_LISA_U::~UBLOX_LISA_U()
-{
-}
+public:
+    UBLOX_PPP(events::EventQueue &queue);
+    virtual ~UBLOX_PPP();
 
-CellularNetwork *UBLOX_LISA_U::open_network(FileHandle *fh)
-{
-    if (!_network) {
-        _network = new UBLOX_LISA_U_CellularNetwork(*get_at_handler(fh));
-    }
-    return _network;
-}
+public: // CellularDevice
+    virtual CellularNetwork *open_network(FileHandle *fh);
+    virtual CellularPower *open_power(FileHandle *fh);
+};
 
-CellularPower *UBLOX_LISA_U::open_power(FileHandle *fh)
-{
-    if (!_power) {
-        _power = new UBLOX_LISA_U_CellularPower(*get_at_handler(fh));
-    }
-    return _power;
-}
+} // namespace mbed
+
+#endif // UBLOX_PPP_H_

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.h
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.h
@@ -34,9 +34,9 @@ public: // CellularDevice
     virtual CellularPower *open_power(FileHandle *fh);
 };
 
+MBED_DEPRECATED_SINCE("mbed-os-5.9", "This API will be deprecated, Use UBLOX_PPP instead of UBLOX_LISA_U.")
 class UBLOX_LISA_U : public UBLOX_PPP
 {
-    MBED_DEPRECATED_SINCE("mbed-os-5.9", "This API will be deprecated, Use UBLOX_PPP instead of UBLOX_LISA_U.");
 };
 
 } // namespace mbed

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.h
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.h
@@ -34,6 +34,11 @@ public: // CellularDevice
     virtual CellularPower *open_power(FileHandle *fh);
 };
 
+class UBLOX_LISA_U : public UBLOX_PPP
+{
+    MBED_DEPRECATED_SINCE("mbed-os-5.9", "This API will be deprecated, Use UBLOX_PPP instead of UBLOX_LISA_U.");
+};
+
 } // namespace mbed
 
 #endif // UBLOX_PPP_H_

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularNetwork.cpp
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularNetwork.cpp
@@ -15,35 +15,30 @@
  * limitations under the License.
  */
 
-#include "UBLOX_LISA_U_CellularPower.h"
-
-#include "onboard_modem_api.h"
+#include "UBLOX_PPP_CellularNetwork.h"
 
 using namespace mbed;
 
-UBLOX_LISA_U_CellularPower::UBLOX_LISA_U_CellularPower(ATHandler &atHandler) : AT_CellularPower(atHandler)
+UBLOX_PPP_CellularNetwork::UBLOX_PPP_CellularNetwork(ATHandler &atHandler) : AT_CellularNetwork(atHandler)
 {
-
 }
 
-UBLOX_LISA_U_CellularPower::~UBLOX_LISA_U_CellularPower()
+UBLOX_PPP_CellularNetwork::~UBLOX_PPP_CellularNetwork()
 {
-
 }
 
-nsapi_error_t UBLOX_LISA_U_CellularPower::on()
+bool UBLOX_PPP_CellularNetwork::get_modem_stack_type(nsapi_ip_stack_t requested_stack)
 {
-#if MODEM_ON_BOARD
-    ::onboard_modem_init();
-    ::onboard_modem_power_up();
-#endif
-    return NSAPI_ERROR_OK;
+    return requested_stack == IPV4_STACK ? true : false;
 }
 
-nsapi_error_t UBLOX_LISA_U_CellularPower::off()
+bool UBLOX_PPP_CellularNetwork::has_registration(RegistrationType reg_type)
 {
-#if MODEM_ON_BOARD
-    ::onboard_modem_power_down();
-#endif
-    return NSAPI_ERROR_OK;
+    return (reg_type == C_REG || reg_type == C_GREG);
+}
+
+nsapi_error_t UBLOX_PPP_CellularNetwork::set_access_technology_impl(operator_t::RadioAccessTechnology opRat)
+{
+    _op_act = operator_t::RAT_UNKNOWN;
+    return NSAPI_ERROR_UNSUPPORTED;
 }

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularNetwork.h
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularNetwork.h
@@ -15,25 +15,27 @@
  * limitations under the License.
  */
 
-#ifndef UBLOX_LISA_U_H_
-#define UBLOX_LISA_U_H_
+#ifndef UBLOX_PPP_CELLULAR_NETWORK_H_
+#define UBLOX_PPP_CELLULAR_NETWORK_H_
 
-#include "AT_CellularDevice.h"
+#include "AT_CellularNetwork.h"
 
 namespace mbed {
 
-class UBLOX_LISA_U : public AT_CellularDevice
+class UBLOX_PPP_CellularNetwork : public AT_CellularNetwork
 {
-
 public:
-    UBLOX_LISA_U(events::EventQueue &queue);
-    virtual ~UBLOX_LISA_U();
+    UBLOX_PPP_CellularNetwork(ATHandler &atHandler);
+    virtual ~UBLOX_PPP_CellularNetwork();
 
-public: // CellularDevice
-    virtual CellularNetwork *open_network(FileHandle *fh);
-    virtual CellularPower *open_power(FileHandle *fh);
+protected:
+    virtual bool get_modem_stack_type(nsapi_ip_stack_t requested_stack);
+
+    virtual bool has_registration(RegistrationType rat);
+
+    virtual nsapi_error_t set_access_technology_impl(operator_t::RadioAccessTechnology opRat);
 };
 
 } // namespace mbed
 
-#endif // UBLOX_LISA_U_H_
+#endif // UBLOX_PPP_CELLULAR_NETWORK_H_

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularNetwork.h
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularNetwork.h
@@ -36,6 +36,11 @@ protected:
     virtual nsapi_error_t set_access_technology_impl(operator_t::RadioAccessTechnology opRat);
 };
 
+class UBLOX_LISA_U_CellularNetwork : public UBLOX_PPP_CellularNetwork
+{
+    MBED_DEPRECATED_SINCE("mbed-os-5.9", "This API will be deprecated, Use UBLOX_PPP_CellularNetwork instead of UBLOX_LISA_U_CellularNetwork.");
+};
+
 } // namespace mbed
 
 #endif // UBLOX_PPP_CELLULAR_NETWORK_H_

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularNetwork.h
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularNetwork.h
@@ -36,9 +36,9 @@ protected:
     virtual nsapi_error_t set_access_technology_impl(operator_t::RadioAccessTechnology opRat);
 };
 
+MBED_DEPRECATED_SINCE("mbed-os-5.9", "This API will be deprecated, Use UBLOX_PPP_CellularNetwork instead of UBLOX_LISA_U_CellularNetwork.")
 class UBLOX_LISA_U_CellularNetwork : public UBLOX_PPP_CellularNetwork
 {
-    MBED_DEPRECATED_SINCE("mbed-os-5.9", "This API will be deprecated, Use UBLOX_PPP_CellularNetwork instead of UBLOX_LISA_U_CellularNetwork.");
 };
 
 } // namespace mbed

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularPower.cpp
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularPower.cpp
@@ -15,27 +15,35 @@
  * limitations under the License.
  */
 
-#ifndef UBLOX_LISA_U_CELLULAR_NETWORK_H_
-#define UBLOX_LISA_U_CELLULAR_NETWORK_H_
+#include "UBLOX_PPP_CellularPower.h"
 
-#include "AT_CellularNetwork.h"
+#include "onboard_modem_api.h"
 
-namespace mbed {
+using namespace mbed;
 
-class UBLOX_LISA_U_CellularNetwork : public AT_CellularNetwork
+UBLOX_PPP_CellularPower::UBLOX_PPP_CellularPower(ATHandler &atHandler) : AT_CellularPower(atHandler)
 {
-public:
-    UBLOX_LISA_U_CellularNetwork(ATHandler &atHandler);
-    virtual ~UBLOX_LISA_U_CellularNetwork();
 
-protected:
-    virtual bool get_modem_stack_type(nsapi_ip_stack_t requested_stack);
+}
 
-    virtual bool has_registration(RegistrationType rat);
+UBLOX_PPP_CellularPower::~UBLOX_PPP_CellularPower()
+{
 
-    virtual nsapi_error_t set_access_technology_impl(operator_t::RadioAccessTechnology opRat);
-};
+}
 
-} // namespace mbed
+nsapi_error_t UBLOX_PPP_CellularPower::on()
+{
+#if MODEM_ON_BOARD
+    ::onboard_modem_init();
+    ::onboard_modem_power_up();
+#endif
+    return NSAPI_ERROR_OK;
+}
 
-#endif // UBLOX_LISA_U_CELLULAR_NETWORK_H_
+nsapi_error_t UBLOX_PPP_CellularPower::off()
+{
+#if MODEM_ON_BOARD
+    ::onboard_modem_power_down();
+#endif
+    return NSAPI_ERROR_OK;
+}

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularPower.h
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularPower.h
@@ -15,18 +15,18 @@
  * limitations under the License.
  */
 
-#ifndef UBLOX_LISA_U_CELLULARPOWER_H_
-#define UBLOX_LISA_U_CELLULARPOWER_H_
+#ifndef UBLOX_PPP_CELLULARPOWER_H_
+#define UBLOX_PPP_CELLULARPOWER_H_
 
 #include "AT_CellularPower.h"
 
 namespace mbed {
 
-class UBLOX_LISA_U_CellularPower : public AT_CellularPower
+class UBLOX_PPP_CellularPower : public AT_CellularPower
 {
 public:
-    UBLOX_LISA_U_CellularPower(ATHandler &atHandler);
-    virtual ~UBLOX_LISA_U_CellularPower();
+    UBLOX_PPP_CellularPower(ATHandler &atHandler);
+    virtual ~UBLOX_PPP_CellularPower();
 
 public: //from CellularPower
 
@@ -37,4 +37,4 @@ public: //from CellularPower
 
 } // namespace mbed
 
-#endif // UBLOX_LISA_U_CELLULARPOWER_H_
+#endif // UBLOX_PPP_CELLULARPOWER_H_

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularPower.h
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularPower.h
@@ -35,9 +35,9 @@ public: //from CellularPower
     virtual nsapi_error_t off();
 };
 
+MBED_DEPRECATED_SINCE("mbed-os-5.9", "This API will be deprecated, Use UBLOX_PPP_CellularPower instead of UBLOX_LISA_U_CellularPower.")
 class UBLOX_LISA_U_CellularPower  : public UBLOX_PPP_CellularPower
 {
-    MBED_DEPRECATED_SINCE("mbed-os-5.9", "This API will be deprecated, Use UBLOX_PPP_CellularPower instead of UBLOX_LISA_U_CellularPower.");
 };
 
 } // namespace mbed

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularPower.h
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularPower.h
@@ -35,6 +35,11 @@ public: //from CellularPower
     virtual nsapi_error_t off();
 };
 
+class UBLOX_LISA_U_CellularPower  : public UBLOX_PPP_CellularPower
+{
+    MBED_DEPRECATED_SINCE("mbed-os-5.9", "This API will be deprecated, Use UBLOX_PPP_CellularPower instead of UBLOX_LISA_U_CellularPower.");
+};
+
 } // namespace mbed
 
 #endif // UBLOX_PPP_CELLULARPOWER_H_


### PR DESCRIPTION
### Description


Renaming UBLOX target library form "UBLOX_LISA_U" to "UBLOX_PPP" for mbed cellular framework.

LISA is not a cellular technology, it is the physical shape of module. Technology used for cellular test is PPP, So changing name from LISA_U to PPP as suggested by kjbracey-arm (Kevin Bracey).

### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [ ] Fix
- [x] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
