### PR TITLE
Cellualr: corrected credentials check

### DIFF
--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -83,15 +83,15 @@ nsapi_error_t AT_CellularNetwork::init()
 
 void AT_CellularNetwork::free_credentials()
 {
-    if (_uname) {
+    if (*_uname) {
         free(_uname);
     }
 
-    if (_pwd) {
+    if (*_pwd) {
         free(_pwd);
     }
 
-    if (_apn) {
+    if (*_apn) {
         free(_apn);
     }
 }


### PR DESCRIPTION
### Description
This pull request fix the wrong check on credentials, _uname, _pwd and _apn.

"if (_uname)" is checking address, which is true and freeing void pointer causing MbedOS Fault Handler. Instead of checking address, check content if content is present then free.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

