### PR TITLE
Cellular : Missing AT_CellularPower header file in CellularPower tests

### DIFF
--- a/features/cellular/TESTS/api/cellular_power/main.cpp
+++ b/features/cellular/TESTS/api/cellular_power/main.cpp
@@ -36,7 +36,7 @@
 #include "utest.h"
 
 #include "mbed.h"
-
+#include "AT_CellularPower.h"
 #include "CellularDevice.h"
 #include "../../cellular_tests_common.h"
 #include CELLULAR_STRINGIFY(CELLULAR_DEVICE.h)


### PR DESCRIPTION
### Description
"AT_CellularPower.h" was missing in the main.cpp file which was causing the build error.
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

