### PR TITLE
Cellular: test_information_interface fix for UBLOX targets

### DIFF
--- a/features/cellular/TESTS/api/cellular_information/main.cpp
+++ b/features/cellular/TESTS/api/cellular_information/main.cpp
@@ -87,6 +87,7 @@ static void test_information_interface()
                ((((AT_CellularInformation *)info)->get_device_error().errType == 3) &&    // 3 == CME error from the modem
                (((AT_CellularInformation *)info)->get_device_error().errCode == 4)));     // 4 == "operation not supported"
 
+#if !defined(TARGET_UBLOX_C027) && !defined(TARGET_UBLOX_C030_R410M)
     nsapi_error_t err = info->get_serial_number(buf, kbuf_size, CellularInformation::IMEI);
     TEST_ASSERT(err == NSAPI_ERROR_UNSUPPORTED || err == NSAPI_ERROR_OK);
 
@@ -95,6 +96,7 @@ static void test_information_interface()
 
     err = info->get_serial_number(buf, kbuf_size, CellularInformation::SVN);
     TEST_ASSERT(err == NSAPI_ERROR_UNSUPPORTED || err == NSAPI_ERROR_OK);
+#endif
 
     cellular.get_device()->close_information();
 


### PR DESCRIPTION
### Description
Information_interface test case is using AT+CGSN command with parameters, which are not supported for TARGET_UBLOX_C027 and TARGET_UBLOX_C030_R410M, causing test failure.
 In [u-blox AT Command Manua](https://www.u-blox.com/sites/default/files/u-blox-CEL_ATCommands_%28UBX-13002752%29.pdf)l and [R410M AT Command Manual](https://www.u-blox.com/sites/default/files/SARA-R4-SARA-N4_ATCommands_%28UBX-17003787%29.pdf) Section 4.7.4: `AT+CGSN=snt`, The `snt` parameter is not supported.
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

