### PR TITLE
Cellular: Added unsupported features for UBLOX targets

### DIFF
--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
@@ -22,8 +22,18 @@
 using namespace mbed;
 using namespace events;
 
+#ifdef TARGET_UBLOX_C030_R410M
+static const AT_CellularBase::SupportedFeature unsupported_features[] =  {
+    AT_CellularBase::AT_CGSN_WITH_TYPE,
+    AT_CellularBase::SUPPORTED_FEATURE_END_MARK
+};
+#endif
+
 UBLOX_AT::UBLOX_AT(EventQueue &queue) : AT_CellularDevice(queue)
 {
+#ifdef TARGET_UBLOX_C030_R410M
+    AT_CellularBase::set_unsupported_features(unsupported_features);
+#endif
 }
 
 UBLOX_AT::~UBLOX_AT()

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.cpp
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.cpp
@@ -22,8 +22,18 @@
 using namespace mbed;
 using namespace events;
 
+#ifdef TARGET_UBLOX_C027
+static const AT_CellularBase::SupportedFeature unsupported_features[] =  {
+    AT_CellularBase::AT_CGSN_WITH_TYPE,
+    AT_CellularBase::SUPPORTED_FEATURE_END_MARK
+};
+#endif
+
 UBLOX_PPP::UBLOX_PPP(EventQueue &queue) : AT_CellularDevice(queue)
 {
+#ifdef TARGET_UBLOX_C027
+    AT_CellularBase::set_unsupported_features(unsupported_features);
+#endif
 }
 
 UBLOX_PPP::~UBLOX_PPP()


### PR DESCRIPTION
### Description
Added unsupported features for different UBLOX targets.`TRAGET_UBLOX_C027` and `TARGET_UBLOX_C030_R410M ` does not support parameters with `AT+CGSN` command.
In [u-blox AT Command Manual](https://www.u-blox.com/sites/default/files/u-blox-CEL_ATCommands_%28UBX-13002752%29.pdf) and [R410M AT Command Manual](https://www.u-blox.com/sites/default/files/SARA-R4-SARA-N4_ATCommands_%28UBX-17003787%29.pdf) Section 4.7.4: AT+CGSN=snt, The snt parameter is not supported.
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

