### PR TITLE
Cellular: Power ON Wait Increased

### DIFF
--- a/features/cellular/TESTS/api/cellular_device/main.cpp
+++ b/features/cellular/TESTS/api/cellular_device/main.cpp
@@ -93,11 +93,7 @@ static void other_methods()
     TEST_ASSERT(device->get_queue() != NULL);
     TEST_ASSERT(device->hard_power_on() == NSAPI_ERROR_OK);
     TEST_ASSERT(device->soft_power_on() == NSAPI_ERROR_OK);
-#ifdef TARGET_UBLOX_C030_U201
     wait(10);
-#else
-    wait(5);
-#endif
     TEST_ASSERT_EQUAL_INT(device->init(), NSAPI_ERROR_OK);
 }
 

--- a/features/cellular/TESTS/api/cellular_device/main.cpp
+++ b/features/cellular/TESTS/api/cellular_device/main.cpp
@@ -93,7 +93,11 @@ static void other_methods()
     TEST_ASSERT(device->get_queue() != NULL);
     TEST_ASSERT(device->hard_power_on() == NSAPI_ERROR_OK);
     TEST_ASSERT(device->soft_power_on() == NSAPI_ERROR_OK);
+#ifdef TARGET_UBLOX_C030_U201
+    wait(10);
+#else
     wait(5);
+#endif
     TEST_ASSERT_EQUAL_INT(device->init(), NSAPI_ERROR_OK);
 }
 


### PR DESCRIPTION
### Description

Increased power up time for module in CellularDevice Test, as UBLOX_C030 power up time is 10-12 sec. 
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
