### PR TITLE
cellular target name change for ublox cellular instance

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/ONBOARD_UBLOX.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/ONBOARD_UBLOX.cpp
@@ -25,7 +25,7 @@ using namespace mbed;
 
 CellularDevice *CellularDevice::get_target_default_instance()
 {
-#if defined(TARGET_UBLOX_C030_R410M)
+#if defined(TARGET_UBLOX_C030_R41XM)
     static UARTSerial serial(MDMTXD, MDMRXD, MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE);
     static ONBOARD_UBLOX_AT device(&serial);
 #elif defined(TARGET_UBLOX_C030_N211)


### PR DESCRIPTION
### Description
Target changed to `TARGET_UBLOX_C030_R41XM` as both `UBLOX_C030_R410M` and `UBLOX_C030_R412M` use same cellular target instance. 
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
