### PR TITLE
Cellular: Setting timeout before send command in gethostbyname.

### DIFF
--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularStack.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularStack.cpp
@@ -449,13 +449,14 @@ nsapi_error_t UBLOX_AT_CellularStack::gethostbyname(const char *host, SocketAddr
     if (address->set_ip_address(host)) {
         err = NSAPI_ERROR_OK;
     } else {
-        // This interrogation can sometimes take longer than the usual 8 seconds
-        _at.cmd_start_stop("+UDNSRN", "=0,", "%s", host);
 #ifdef TARGET_UBLOX_C030_R41XM
         _at.set_at_timeout(70000);
 #else
         _at.set_at_timeout(120000);
 #endif
+        // This interrogation can sometimes take longer than the usual 8 seconds
+        _at.cmd_start_stop("+UDNSRN", "=0,", "%s", host);
+
         _at.resp_start("+UDNSRN:");
         if (_at.info_resp()) {
             _at.read_string(ipAddress, sizeof(ipAddress));


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

In ublox cellualr api's, setting `timeout `before send command in `gethostbyname`.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
