### PR TITLE
Cellular: updated cellular context flags and cid in ublox-api

### DIFF
--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.cpp
@@ -56,6 +56,13 @@ void UBLOX_AT_CellularContext::do_connect()
 #ifndef TARGET_UBLOX_C030_R41XM
     _cb_data.error = define_context();
 #elif TARGET_UBLOX_C030_R410M
+    _at.cmd_start_stop("+CGACT", "?");
+    _at.resp_start("+CGACT:");
+    _cid = _at.read_int();
+    _at.skip_param(1);
+    _at.resp_stop();
+
+    _is_connected = true;
     _is_context_active = true;
     _is_context_activated = true;
     _cb_data.error = NSAPI_ERROR_OK;
@@ -74,11 +81,19 @@ void UBLOX_AT_CellularContext::do_connect()
             _at.restore_at_timeout();
             if (_is_context_activated == true) {
                 _cid = 1;
+                _is_connected = true;
                 _is_context_active = true;
                 _cb_data.error = NSAPI_ERROR_OK;
             }
         }
     } else if (rat == CellularNetwork::RadioAccessTechnology::RAT_CATM1 || rat == CellularNetwork::RadioAccessTechnology::RAT_NB1) {
+        _at.cmd_start_stop("+CGACT", "?");
+        _at.resp_start("+CGACT:");
+        _cid = _at.read_int();
+        _at.skip_param(1);
+        _at.resp_stop();
+
+        _is_connected = true;
         _is_context_active = true;
         _is_context_activated = true;
         _cb_data.error = NSAPI_ERROR_OK;


### PR DESCRIPTION
### Description

Updated cellular context flags and cid in `ublox_at_cellularcontext `for `UBLOX_C030_R410M` and `UBLOX_C030_R412M `(CAT-M1 and NB1).  In these cases `R410M `and `R412M` modem its self activates context, so reading which context is defined, updating `_cid` and flags.
### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
