### PR TITLE
Added UBLOX_modem_api for power up modem UBLOX_C027.

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/ONBOARD_UBLOX_PPP.cpp
+++ b/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/ONBOARD_UBLOX_PPP.cpp
@@ -17,12 +17,7 @@
 #if MBED_CONF_NSAPI_PRESENT
 
 #include "ONBOARD_UBLOX_PPP.h"
-
-#include "ublox_low_level_api.h"
-#include "gpio_api.h"
-#include "platform/mbed_thread.h"
-#include "PinNames.h"
-
+#include "UBLOX_onboard_modem_api.h"
 #include "drivers/BufferedSerial.h"
 #include "CellularLog.h"
 
@@ -34,45 +29,26 @@ ONBOARD_UBLOX_PPP::ONBOARD_UBLOX_PPP(FileHandle *fh) : UBLOX_PPP(fh)
 
 nsapi_error_t ONBOARD_UBLOX_PPP::hard_power_on()
 {
-    //currently USB is not supported, so pass 0 to disable USB
-    //This call does everything except actually pressing the power button
-    ublox_mdm_powerOn(0);
-
+    ::onboard_modem_init();
     return NSAPI_ERROR_OK;
 }
 
 nsapi_error_t ONBOARD_UBLOX_PPP::hard_power_off()
 {
-    ublox_mdm_powerOff();
-
+    ::onboard_modem_deinit();
     return NSAPI_ERROR_OK;
 }
 
 nsapi_error_t ONBOARD_UBLOX_PPP::soft_power_on()
 {
-    /* keep the power line low for 150 milisecond */
-    press_power_button(150);
-    /* give modem a little time to respond */
-    thread_sleep_for(100);
-
+    ::onboard_modem_power_up();
     return NSAPI_ERROR_OK;
 }
 
 nsapi_error_t ONBOARD_UBLOX_PPP::soft_power_off()
 {
-    /* keep the power line low for 1 second */
-    press_power_button(1000);
-
+    ::onboard_modem_power_down();
     return NSAPI_ERROR_OK;
-}
-
-void ONBOARD_UBLOX_PPP::press_power_button(int time_ms)
-{
-    gpio_t gpio;
-
-    gpio_init_out_ex(&gpio, MDMPWRON, 0);
-    thread_sleep_for(time_ms);
-    gpio_write(&gpio, 1);
 }
 
 CellularDevice *CellularDevice::get_target_default_instance()

--- a/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/ONBOARD_UBLOX_PPP.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/ONBOARD_UBLOX_PPP.h
@@ -29,9 +29,6 @@ public:
     virtual nsapi_error_t hard_power_off();
     virtual nsapi_error_t soft_power_on();
     virtual nsapi_error_t soft_power_off();
-
-private:
-    void press_power_button(int time_ms);
 };
 
 } // namespace mbed

--- a/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/UBLOX_onboard_modem_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/UBLOX_onboard_modem_api.c
@@ -1,0 +1,62 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2020 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if MBED_CONF_NSAPI_PRESENT
+
+#include "UBLOX_onboard_modem_api.h"
+#include "gpio_api.h"
+#include "platform/mbed_wait_api.h"
+#include "platform/mbed_thread.h"
+#include "PinNames.h"
+
+static void press_power_button(time_ms)
+{
+    gpio_t gpio;
+
+    gpio_init_out_ex(&gpio, MDMPWRON, 0);
+    thread_sleep_for(time_ms);
+    gpio_write(&gpio, 1);
+}
+
+void onboard_modem_init()
+{
+    //currently USB is not supported, so pass 0 to disable USB
+    //This call does everything except actually pressing the power button
+    ublox_mdm_powerOn(0);
+}
+
+void onboard_modem_deinit()
+{
+    ublox_mdm_powerOff();
+}
+
+void onboard_modem_power_up()
+{
+    /* keep the power line low for 150 microseconds */
+    press_power_button(150);
+
+    /* give modem a little time to respond */
+    thread_sleep_for(100);
+}
+
+void onboard_modem_power_down()
+{
+    /* keep the power line low for 1 seconds */
+    press_power_button(1000);
+}
+
+#endif //MBED_CONF_NSAPI_PRESENT

--- a/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/UBLOX_onboard_modem_api.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/UBLOX_onboard_modem_api.h
@@ -1,0 +1,54 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2020 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef UBLOX_ONBOARD_MODEM_API_H_
+#define UBLOX_ONBOARD_MODEM_API_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Sets the modem up for powering on
+ *  modem_init() will be equivalent to plugging in the device, i.e.,
+ *  attaching power and serial port.
+ */
+void onboard_modem_init(void);
+
+/** Sets the modem in unplugged state
+ *  modem_deinit() will be equivalent to pulling the plug off of the device, i.e.,
+ *  detaching power and serial port.
+ *  This puts the modem in lowest power state.
+ */
+void onboard_modem_deinit(void);
+
+/** Powers up the modem
+ *  modem_power_up() will be equivalent to pressing the soft power button.
+ *  The driver may repeat this if the modem is not responsive to AT commands.
+
+ */
+void onboard_modem_power_up(void);
+
+/** Powers down the modem
+ *  modem_power_down() will be equivalent to turning off the modem by button press.
+ */
+void onboard_modem_power_down(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UBLOX_ONBOARD_MODEM_API_H_ */


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Added UBLOX_modem_api for powering up modem. As `onboard_modem_api` is removed and functionality of  `onboard_modem_api` is added in  [ONBOARD_UBLOX_PPP](https://github.com/ARMmbed/mbed-os/blob/ee1d998d43cf3dfad03c811b9de616e04b339cde/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/ONBOARD_UBLOX_PPP.cpp#L39). For cellular api's this class, `ONBOARD_UBLOX_PPP`, is inherited from [UBLOX_PPP](https://github.com/ARMmbed/mbed-os/blob/ee1d998d43cf3dfad03c811b9de616e04b339cde/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/ONBOARD_UBLOX_PPP.h#L24), which ultimately initialize cellular [ATHandler](https://github.com/ARMmbed/mbed-os/blob/ee1d998d43cf3dfad03c811b9de616e04b339cde/features/cellular/framework/AT/AT_CellularDevice.cpp#L190).

Problem occurs, when I use `ONBOARD_UBLOX_PPP` class in my own libraries to power up modem 
 then it initialize cellular [ATHandler](https://github.com/ARMmbed/mbed-os/blob/ee1d998d43cf3dfad03c811b9de616e04b339cde/features/cellular/framework/AT/AT_CellularDevice.cpp#L190)  and failed to initialize my `ATCmdParser`.


<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
